### PR TITLE
Fix for bug where ExtensionsForBindingSyntax.ToMock<T>() always returns null

### DIFF
--- a/src/Ninject.MockingKernel/ExtensionsForBindingSyntax.cs
+++ b/src/Ninject.MockingKernel/ExtensionsForBindingSyntax.cs
@@ -34,9 +34,9 @@ namespace Ninject.MockingKernel
         /// <typeparam name="T">The service that is being mocked.</typeparam>
         /// <param name="builder">The builder that is building the binding.</param>
         /// <returns>The syntax for adding more information to the binding.</returns>
-        public static IBindingWhenInNamedWithOrOnSyntax<T> ToMock<T>(this IBindingToSyntax<T> binding) 
+        public static IBindingWhenInNamedWithOrOnSyntax<T> ToMock<T>(this IBindingToSyntax<T> builder) 
         {
-            return binding.ToMethod(CreateMockObject<T>);
+            return builder.ToMethod(CreateMockObject<T>);
         }
 
         private static T CreateMockObject<T>(IContext ctx) 
@@ -56,9 +56,9 @@ namespace Ninject.MockingKernel
         /// <typeparam name="T">The service that is being mocked.</typeparam>
         /// <param name="builder">The builder that is building the binding.</param>
         /// <returns>The syntax for adding more information to the binding.</returns>
-        public static IBindingNamedWithOrOnSyntax<T> ToMockSingleton<T>(this IBindingToSyntax<T> binding) 
+        public static IBindingNamedWithOrOnSyntax<T> ToMockSingleton<T>(this IBindingToSyntax<T> builder) 
         {
-            return binding.ToMock().InSingletonScope();
+            return builder.ToMock().InSingletonScope();
         }
     }
 }


### PR DESCRIPTION
There was a problem where the `ExtensionsForBindingSyntax.ToMock<T>()` method always returns null. See the following line:

``` C#
return builder as IBindingWhenInNamedWithOrOnSyntax<T>;
```

`builder` will never be of type `IBindingWhenInNamedWithOrOnSyntax<T>`.

I have also a method that calls `IBindingWhenInNamedWithOrOnSyntax<T>.ToSingleton()` for convience as this is what one usually wants in a unit test.
