### PR TITLE
Support additional interfaces when mock

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,3 +1,7 @@
+Version 3.2.1.0
+---------------
+Added: Support additional interfaces when mock
+
 Version 3.0.0.0
 ---------------
 Removed: No web builds. All builds are have not reference to web anymore

--- a/src/Ninject.MockingKernel.Moq.Test/MoqIntegrationTest.cs
+++ b/src/Ninject.MockingKernel.Moq.Test/MoqIntegrationTest.cs
@@ -124,6 +124,14 @@ namespace Ninject.MockingKernel.Moq
                     throw new NotImplementedException();
                 }
             }
+
+            public MethodInfo AddAdditionalInterfaceMethod
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
         }
 #endif
     }

--- a/src/Ninject.MockingKernel.Moq/DefaultMockRepositoryProvider.cs
+++ b/src/Ninject.MockingKernel.Moq/DefaultMockRepositoryProvider.cs
@@ -45,6 +45,11 @@ namespace Ninject.MockingKernel.Moq
         private MethodInfo createMethod;
 
         /// <summary>
+        /// Gets the method info of the add additional interface method.
+        /// </summary>
+        private MethodInfo addAdditionalInterfaceMethod;
+
+        /// <summary>
         /// Gets the instance of the mock repository.
         /// </summary>
         /// <value>The instance of the mock repository.</value>
@@ -75,6 +80,23 @@ namespace Ninject.MockingKernel.Moq
                 }
 
                 return this.createMethod;
+            }
+        }
+
+        /// <summary>
+        /// Gets the method info of the add additional interface method.
+        /// </summary>
+        /// <value>The method info of the add additional interface method.</value>
+        public MethodInfo AddAdditionalInterfaceMethod
+        {
+            get
+            {
+                if (this.addAdditionalInterfaceMethod == null)
+                {
+                    this.addAdditionalInterfaceMethod = typeof(Mock).GetMethod("As");
+                }
+
+                return this.addAdditionalInterfaceMethod;
             }
         }
     }

--- a/src/Ninject.MockingKernel.Moq/IMockRepositoryProvider.cs
+++ b/src/Ninject.MockingKernel.Moq/IMockRepositoryProvider.cs
@@ -42,6 +42,12 @@ namespace Ninject.MockingKernel.Moq
         /// </summary>
         /// <value>The method info of the create method.</value>
         MethodInfo CreateMethod { get; }
+
+        /// <summary>
+        /// Gets the method info of the add additional interface method.
+        /// </summary>
+        /// <value>the method info of the add additional interface method.</value>
+        MethodInfo AddAdditionalInterfaceMethod { get; }
     }
 }
 #endif

--- a/src/Ninject.MockingKernel.Moq/MoqMockProvider.cs
+++ b/src/Ninject.MockingKernel.Moq/MoqMockProvider.cs
@@ -22,6 +22,7 @@
 namespace Ninject.MockingKernel.Moq
 {
     using System;
+    using System.Linq;
     using System.Reflection;
 
     using global::Moq;
@@ -46,6 +47,11 @@ namespace Ninject.MockingKernel.Moq
         private readonly MethodInfo createMethod;
 
         /// <summary>
+        /// The method info used to add additional interface to mock.
+        /// </summary>
+        private readonly MethodInfo addAdditionalInterfaceMethod;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MoqMockProvider"/> class.
         /// </summary>
         /// <param name="mockRepositoryProvider">The mock repository provider used to create mock instances.</param>
@@ -53,6 +59,7 @@ namespace Ninject.MockingKernel.Moq
         {
             this.mockRepository = mockRepositoryProvider.Instance;
             this.createMethod = mockRepositoryProvider.CreateMethod;
+            this.addAdditionalInterfaceMethod = mockRepositoryProvider.AddAdditionalInterfaceMethod;
         }
 #endif
 
@@ -87,6 +94,12 @@ namespace Ninject.MockingKernel.Moq
         {
             var methodInfo = this.createMethod.MakeGenericMethod(context.Request.Service);
             var mock = (Mock)methodInfo.Invoke(this.mockRepository, new object[0]);
+            var additionalInterfaces = context.Parameters.OfType<AdditionalInterfaceParameter>().Select(ai => (Type)ai.GetValue(context, null));
+            foreach (var additionalInterface in additionalInterfaces)
+            {
+                this.addAdditionalInterfaceMethod.MakeGenericMethod(additionalInterface).Invoke(mock, null);
+            }
+
             return mock.Object;
         }
 
@@ -104,6 +117,12 @@ namespace Ninject.MockingKernel.Moq
             var mockType = typeof(Mock<>).MakeGenericType(context.Request.Service);
             var constructorInfo = mockType.GetConstructor(new[] { typeof(MockBehavior) });
             var mock = (Mock)constructorInfo.Invoke(new object[] { Settings.GetMockBehavior() });
+            var additionalInterfaces = context.Parameters.OfType<AdditionalInterfaceParameter>().Select(ai => (Type)ai.GetValue(context, null));
+            foreach (var additionalInterface in additionalInterfaces)
+            {
+                typeof(Mock).GetMethod("As").MakeGenericMethod(additionalInterface).Invoke(mock, null);
+            }
+
             return mock.Object;
         }
 #endif

--- a/src/Ninject.MockingKernel.NSubstitute/NSubstituteMockProvider.cs
+++ b/src/Ninject.MockingKernel.NSubstitute/NSubstituteMockProvider.cs
@@ -22,6 +22,7 @@
 namespace Ninject.MockingKernel.NSubstitute
 {
     using System;
+    using System.Linq;
     using Activation;
     using Components;
     using global::NSubstitute;
@@ -61,7 +62,9 @@ namespace Ninject.MockingKernel.NSubstitute
         /// </returns>
         public object Create(IContext context)
         {
-            return Substitute.For(new[] { context.Request.Service }, null);
+            var additionalInterfaces = context.Parameters.OfType<AdditionalInterfaceParameter>().Select(ai => (Type)ai.GetValue(context, null));
+
+            return Substitute.For(new[] { context.Request.Service }.Concat(additionalInterfaces).ToArray(), null);
         }
     }
 }

--- a/src/Ninject.MockingKernel.RhinoMock/RhinoMocksMockProvider.cs
+++ b/src/Ninject.MockingKernel.RhinoMock/RhinoMocksMockProvider.cs
@@ -35,21 +35,6 @@ namespace Ninject.MockingKernel.RhinoMock
     /// </summary>
     public class RhinoMocksMockProvider : NinjectComponent, IProvider, IMockProviderCallbackProvider
     {
-#if SILVERLIGHT
-        /// <summary>
-        /// The method info for creation mocks.
-        /// </summary>
-        private readonly MethodInfo generateMockMethodInfo;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RhinoMocksMockProvider"/> class.
-        /// </summary>
-        public RhinoMocksMockProvider()
-        {
-            this.generateMockMethodInfo = typeof(MockRepository).GetMethod("GenerateMock");
-        }
-#endif
-
         /// <summary>
         /// Gets the type (or prototype) of instances the provider creates.
         /// </summary>
@@ -68,11 +53,9 @@ namespace Ninject.MockingKernel.RhinoMock
         /// <returns>The created instance.</returns>
         public object Create(IContext context)
         {
-#if !SILVERLIGHT
-            return MockRepository.GenerateMock(context.Request.Service, new Type[0], new object[0]);
-#else
-            return this.generateMockMethodInfo.MakeGenericMethod(context.Request.Service).Invoke(null, new[] { new object[0] });
-#endif
+            var additionalInterfaces = context.Parameters.OfType<AdditionalInterfaceParameter>().Select(ai => (Type)ai.GetValue(context, null)).ToArray();
+
+            return MockRepository.GenerateMock(context.Request.Service, additionalInterfaces, new object[0]);
         }
 
         /// <summary>

--- a/src/Ninject.MockingKernel.Test/IDummyService2.cs
+++ b/src/Ninject.MockingKernel.Test/IDummyService2.cs
@@ -1,0 +1,34 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IDummyService2.cs" company="bbv Software Services AG">
+//   Copyright (c) 2010 bbv Software Services AG
+//   Author: Remo Gloor remo.gloor@bbv.ch
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+//   Also licenced under Microsoft Public License (Ms-PL).
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Ninject.MockingKernel
+{
+    /// <summary>
+    /// A dummy interface
+    /// </summary>
+    public interface IDummyService2
+    {
+        /// <summary>
+        /// A dummy method.
+        /// </summary>
+        void Do2();
+    }
+}

--- a/src/Ninject.MockingKernel.Test/IntegrationTest.cs
+++ b/src/Ninject.MockingKernel.Test/IntegrationTest.cs
@@ -63,6 +63,22 @@ namespace Ninject.MockingKernel
         }
 
         /// <summary>
+        /// The ToMock extension can be used to add additional interfaces.
+        /// </summary>
+        [Fact]
+        public void ToMockCanBeUsedToAddAdditionalInterfaces()
+        {
+            using (var kernel = this.CreateKernel())
+            {
+                kernel.Bind<IDummyService>().ToMock(typeof(IDummyService2));
+
+                var mock = kernel.Get<IDummyService>();
+
+                mock.Should().BeAssignableTo<IDummyService2>();
+            }
+        }
+
+        /// <summary>
         /// Reals the objects are created for auto bindable types.
         /// </summary>
         [Fact]

--- a/src/Ninject.MockingKernel.Test/Ninject.MockingKernel.Test.csproj
+++ b/src/Ninject.MockingKernel.Test/Ninject.MockingKernel.Test.csproj
@@ -71,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IDummyService.cs" />
+    <Compile Include="IDummyService2.cs" />
     <Compile Include="IntegrationTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Ninject.MockingKernel/AdditionalInterfaceParameter.cs
+++ b/src/Ninject.MockingKernel/AdditionalInterfaceParameter.cs
@@ -1,0 +1,90 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="AdditionalInterfaceParameter.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2014 Ninject Project Contributors Authors: Scott Xu
+//   (scott-xu@msn.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+namespace Ninject.MockingKernel
+{
+    using System;
+    using Ninject.Activation;
+    using Ninject.Parameters;
+    using Ninject.Planning.Targets;
+
+    /// <summary>
+    /// Additional Interfaces
+    /// </summary>
+    public class AdditionalInterfaceParameter : IParameter
+    {
+        /// <summary>
+        /// The type of additional interface.
+        /// </summary>
+        private Type additionalInterface;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdditionalInterfaceParameter"/> class.
+        /// </summary>
+        /// <param name="additionalInterface">The type of additional interface</param>
+        public AdditionalInterfaceParameter(Type additionalInterface)
+        {
+            this.additionalInterface = additionalInterface;
+        }
+
+        /// <summary>
+        /// Gets the name of the parameter.
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the parameter should be inherited into child requests.
+        /// </summary>
+        public bool ShouldInherit
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Get the interface array
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="target">The target</param>
+        /// <returns>The interface type</returns>
+        public object GetValue(IContext context, ITarget target)
+        {
+            return this.additionalInterface;
+        }
+
+        /// <summary>
+        /// Determines whether the object equals the specified object.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns><c>True</c> if the objects are equal; otherwise <c>false</c></returns>
+        public bool Equals(IParameter other)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Ninject.MockingKernel/ExtensionsForBindingSyntax.cs
+++ b/src/Ninject.MockingKernel/ExtensionsForBindingSyntax.cs
@@ -21,6 +21,7 @@
 
 namespace Ninject.MockingKernel
 {
+    using System;
     using Ninject.Syntax;
 
     /// <summary>
@@ -33,12 +34,19 @@ namespace Ninject.MockingKernel
         /// </summary>
         /// <typeparam name="T">The service that is being mocked.</typeparam>
         /// <param name="builder">The builder that is building the binding.</param>
+        /// <param name="additionalInterfaces">The additional interfaces for the mock.</param>
         /// <returns>The syntax for adding more information to the binding.</returns>
-        public static IBindingWhenInNamedWithOrOnSyntax<T> ToMock<T>(this IBindingToSyntax<T> builder)
+        public static IBindingWhenInNamedWithOrOnSyntax<T> ToMock<T>(this IBindingToSyntax<T> builder, params Type[] additionalInterfaces)
         {
             var result = builder.To<T>();
 
             var bindingConfiguration = builder.BindingConfiguration;
+
+            foreach (var additionalInterface in additionalInterfaces)
+            {
+                bindingConfiguration.Parameters.Add(new AdditionalInterfaceParameter(additionalInterface));
+            }
+
             bindingConfiguration.ProviderCallback = builder.Kernel.Components.Get<IMockProviderCallbackProvider>().GetCreationCallback();
 
             return result;

--- a/src/Ninject.MockingKernel/Ninject.MockingKernel.csproj
+++ b/src/Ninject.MockingKernel/Ninject.MockingKernel.csproj
@@ -71,6 +71,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AdditionalInterfaceParameter.cs" />
     <Compile Include="ExtensionsForBindingSyntax.cs" />
     <Compile Include="IMockProviderCallbackProvider.cs" />
     <Compile Include="MockMissingBindingResolver.cs" />


### PR DESCRIPTION
Hi @remogloor , This PR is to implement additional interfaces when mock. The use case is as below. Can you please help have a review?

``` C#
[Fact]
public void ToMockCanBeUsedToAddAdditionalInterfaces()
{
    using (var kernel = this.CreateKernel())
    {
        kernel.Bind<IDummyService>().ToMock(typeof(IDummyService2));

        var mock = kernel.Get<IDummyService>();

        mock.Should().BeAssignableTo<IDummyService2>();
    }
}
```
