### PR TITLE
Support CallBase and DefaultValue configuration of Moq.MockFactory.

### DIFF
--- a/src/Ninject.MockingKernel.Moq.Test/DefaultMockRepositoryProviderTest.cs
+++ b/src/Ninject.MockingKernel.Moq.Test/DefaultMockRepositoryProviderTest.cs
@@ -36,6 +36,8 @@ namespace Ninject.MockingKernel.Moq
             var mock = testee.Instance.Create<IDummyService>();
                 
             mock.Behavior.Should().Be(MockBehavior.Default);
+            mock.CallBase.Should().Be(false);
+            mock.DefaultValue.Should().Be(DefaultValue.Empty);
         }
 
         [Fact]
@@ -47,6 +49,28 @@ namespace Ninject.MockingKernel.Moq
 
             var mock = testee.Instance.Create<IDummyService>();
             mock.Behavior.Should().Be(MockBehavior.Strict);
+        }
+
+        [Fact]
+        public void CreatesMocksWithTheConfiguredCallBaseBehavior()
+        {
+            var settings = new NinjectSettings();
+            settings.SetMockCallBase(true);
+            var testee = new DefaultMockRepositoryProvider { Settings = settings };
+
+            var mock = testee.Instance.Create<IDummyService>();
+            mock.CallBase.Should().Be(true);
+        }
+
+        [Fact]
+        public void CreatesMocksWithTheConfiguredDefaultReturnValue()
+        {
+            var settings = new NinjectSettings();
+            settings.SetMockDefaultValue(DefaultValue.Mock);
+            var testee = new DefaultMockRepositoryProvider { Settings = settings };
+
+            var mock = testee.Instance.Create<IDummyService>();
+            mock.DefaultValue.Should().Be(DefaultValue.Mock);
         }
     }
 }

--- a/src/Ninject.MockingKernel.Moq/DefaultMockRepositoryProvider.cs
+++ b/src/Ninject.MockingKernel.Moq/DefaultMockRepositoryProvider.cs
@@ -60,6 +60,8 @@ namespace Ninject.MockingKernel.Moq
                 if (this.instance == null)
                 {
                     this.instance = new MockRepository(this.Settings.GetMockBehavior());                                    
+                    this.instance.CallBase = this.Settings.GetMockCallBase();
+                    this.instance.DefaultValue = this.Settings.GetMockDefaultValue();
                 }
 
                 return this.instance;

--- a/src/Ninject.MockingKernel.Moq/NinjectSettingsExtensions.cs
+++ b/src/Ninject.MockingKernel.Moq/NinjectSettingsExtensions.cs
@@ -34,6 +34,16 @@ namespace Ninject.MockingKernel.Moq
         private const string MockBehaviorSettingsKey = "MockBehavior";
 
         /// <summary>
+        /// The key used to store the mock call base behavior in the ninject settings.
+        /// </summary>
+        private const string MockCallBase = "MockCallBase";
+
+        /// <summary>
+        /// The key used to store the mock default return value in the ninject settings.
+        /// </summary>
+        private const string MockDefaultValue = "MockDefaultValue";
+
+        /// <summary>
         /// Sets the mock behavior.
         /// </summary>
         /// <param name="settings">The ninject settings.</param>
@@ -51,6 +61,46 @@ namespace Ninject.MockingKernel.Moq
         public static MockBehavior GetMockBehavior(this INinjectSettings settings)
         {
             return settings.Get(MockBehaviorSettingsKey, MockBehavior.Default);
+        }
+
+        /// <summary>
+        /// Sets the mock call base behavior.
+        /// </summary>
+        /// <param name="settings">The ninject settings.</param>
+        /// <param name="mockCallBase">The mock call base behavior.</param>
+        public static void SetMockCallBase(this INinjectSettings settings, bool mockCallBase)
+        {
+            settings.Set(MockCallBase, mockCallBase);
+        }
+
+        /// <summary>
+        /// Gets the mock call base behavior.
+        /// </summary>
+        /// <param name="settings">The ninject settings.</param>
+        /// <returns>The configured mock call base behavior.</returns>
+        public static bool GetMockCallBase(this INinjectSettings settings)
+        {
+            return settings.Get(MockCallBase, false);
+        }
+
+        /// <summary>
+        /// Sets the mock default return value.
+        /// </summary>
+        /// <param name="settings">The ninject settings.</param>
+        /// <param name="mockDefaultValue">The mock default return value.</param>
+        public static void SetMockDefaultValue(this INinjectSettings settings, DefaultValue mockDefaultValue)
+        {
+            settings.Set(MockDefaultValue, mockDefaultValue);
+        }
+
+        /// <summary>
+        /// Gets the mock default return value.
+        /// </summary>
+        /// <param name="settings">The ninject settings.</param>
+        /// <returns>The configured mock default return value.</returns>
+        public static DefaultValue GetMockDefaultValue(this INinjectSettings settings)
+        {
+            return settings.Get(MockDefaultValue, DefaultValue.Empty);
         }
     }
 }


### PR DESCRIPTION
At times, I find it handy to make test mocks automatically return new mocks (for unregistered calls). I found no way to configure this using Ninject.MockingKernel.Moq, and decided to implement it myself.

(I usually don't set the CallBase flag, but decided to implement that as a Ninject setting as well, for completeness.)
